### PR TITLE
Introduce Makefile to consolidate project tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: *
+.DEFAULT_GOAL := docker/app/run
+
+export DOCKER_BUILDKIT?=1
+
+docker/app/build:
+	docker build --tag adrianolmedo/bcvcurs:dev-local .
+
+docker/app/run: docker/app/build
+	docker run \
+		--rm \
+		-d \
+		-p 8080:80 \
+		--name bcvcurs \
+		adrianolmedo/bcvcurs:dev-local
+
+docker/app/stop:
+	docker stop bcvcurs
+
+docker/app/restart: docker/app/stop docker/app/run

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ $ bcvcurs -addr localhost -port 8080
 
 ```bash
 $ git clone https://github.com/adrianolmedo/bcvcurs.git
-$ docker build --tag bcvcurs:0.1 .
-$ docker run -d -p 8080:80 --name bcvcurs bcvcurs:0.1
+$ make
 ```
-
+Note: `make` by default runs the target defined in the `.DEFAULT_GOAL` variable of the `Makefile`
 ## Endpoints
 
 ### **All currencies**


### PR DESCRIPTION
The intent of this change is to start using Makefile to build future project tooling and orchestration which makes easier to work with the project by making explicit environment variables that often are implicit and may not be defined in the developers computers.

The makefile will work out of the box for Unix based systems which include Mac OS, Ubuntu, Fedora and other Linux distributions, since they all ship with GNU Make (via `make` command).

In this changeset, we set the default target of `make` to `docker/app/run` which will execute `docker/app/build` target to build the Docker image needed.

When you want to stop and remove the container, you can run `make docker/app/stop` and it will stop the Docker container.

Other noteworthy addition is the `DOCKER_BUILDKIT` variable set to `1` which is assigned in case it is not present in the environment. This enables a more optimized build process of the Docker image.